### PR TITLE
Change the way passing parameters to front-end intervals

### DIFF
--- a/back-end/routes/redis.js
+++ b/back-end/routes/redis.js
@@ -9,25 +9,6 @@ const {
 } = require("../utils/low-dependency/PromisesUtil");
 
 /**
- * Keys list:
- * - '${email}|transactionsHistoryList': list
- * - '${email}|transactionsHistoryM5RU': list -> Most 5 recently used
- * - '${email}|transactionsHistoryM5RU|numberOfChunksSkipped|filters|orderBy|orderQuery': list
- * - '${email}|passwordVerification': value
- * - '${email}|accountSummaryChart': list
- * - '${email}|sharesList': list
- *
- * - 'cachedMarketHoliday': value
- *
- * - 'cachedShares': list
- * - 'cachedShares|${companyCode}|quote': value
- * - 'cachedShares|${companyCode}|profile': value
- *
- * - 'RANKING_LIST': list
- * - 'RANKING_LIST_${region}': list
- */
-
-/**
  * 'doanhtu07@gmail.com|accountSummaryChart' : list -> "timestamp1|value1", "timestamp2|value2", ...
  */
 router.put("/updateAccountSummaryChartWholeList", (req, res) => {

--- a/back-end/utils/redis-utils/RedisUtil.js
+++ b/back-end/utils/redis-utils/RedisUtil.js
@@ -41,6 +41,12 @@ const {
  * - 'RANKING_LIST_${region}': list
  */
 
+const transactionsHistoryList = "transactionsHistoryList";
+const transactionsHistoryM5RU = "transactionsHistoryM5RU";
+const passwordVerification = "passwordVerification";
+const accountSummaryChart = "accountSummaryChart";
+const sharesList = "sharesList";
+
 /**
  * @returns true if market is closed, false if market is opened
  */
@@ -224,7 +230,26 @@ const cleanUserCache = (email) => {
   });
 };
 
+const cleanChosenUserCache = (email, chosenKey) => {
+  return new Promise((resolve, reject) => {
+    delAsync(`${email}|${chosenKey}`)
+      .then((successfullyCleanKey) => {
+        resolve("Successful");
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
+};
+
 module.exports = {
+  // Keys
+  transactionsHistoryList,
+  transactionsHistoryM5RU,
+  passwordVerification,
+  accountSummaryChart,
+  sharesList,
+
   // Market Time
   isMarketClosedCheck,
 
@@ -241,5 +266,6 @@ module.exports = {
   getCachedMarketHoliday,
   updateCachedMarketHoliday,
 
-  cleanUserCache
+  cleanUserCache,
+  cleanChosenUserCache
 };

--- a/front-end/src/components/Dialog/TransactionsHistoryFilterDialog.js
+++ b/front-end/src/components/Dialog/TransactionsHistoryFilterDialog.js
@@ -97,6 +97,7 @@ const styles = (theme) => ({
     "&:hover": {
       backgroundColor: theme.palette.fail.backgroundColorHover,
     },
+    zIndex: theme.customZIndex.floatingActionButton,
   },
   hide: {
     display: "none",

--- a/front-end/src/components/Layout/setupForCachingInLayout.js
+++ b/front-end/src/components/Layout/setupForCachingInLayout.js
@@ -15,31 +15,31 @@ import {
   newDate,
 } from "../../utils/low-dependency/DayTimeUtil";
 
-const setupSharesListForCaching = (isMarketClosed, userSession, mutateUser) => {
+const setupSharesListForCaching = (thisComponent) => {
+  const { email } = thisComponent.props.userSession;
+
   return new Promise((resolve, reject) => {
-    getCachedSharesList(userSession.email)
+    getCachedSharesList(email)
       .then((res) => {
         const { data: cachedShares } = res;
         if (isEmpty(cachedShares)) {
           const dataNeeded = {
             shares: true,
           };
-          return getUserData(dataNeeded, userSession.email);
+          return getUserData(dataNeeded, email);
         }
       })
       .then((sharesData) => {
         if (sharesData) {
           const { shares } = sharesData;
           if (shares && !isEmpty(shares)) {
-            return updateCachedSharesList(userSession.email, shares);
+            return updateCachedSharesList(email, shares);
           }
         }
       })
       .then((afterUpdatingCachedSharesList) => {
         // checkStockQuotesToCalculateSharesValue(
-        //   isMarketClosed,
-        //   userSession,
-        //   mutateUser
+        //   thisComponent
         // );
         resolve("Finished setting up Redis Shares List.");
       })
@@ -49,22 +49,24 @@ const setupSharesListForCaching = (isMarketClosed, userSession, mutateUser) => {
   });
 };
 
-const setupAccountSummaryChartForCaching = (userSession) => {
+const setupAccountSummaryChartForCaching = (thisComponent) => {
+  const { email } = thisComponent.props.userSession;
+
   return new Promise((resolve, reject) => {
-    getCachedAccountSummaryChartInfo(userSession.email)
+    getCachedAccountSummaryChartInfo(email)
       .then((res) => {
         const { data: chartInfo } = res;
         if (isEmpty(chartInfo)) {
           return getUserAccountSummaryChartTimestamps(
             getYearUTCString(newDate()) - 2,
-            userSession.email
+            email
           );
         }
       })
       .then((chartInfoFromDatabase) => {
         if (chartInfoFromDatabase && !isEmpty(chartInfoFromDatabase)) {
           return updateCachedAccountSummaryChartInfoWholeList(
-            userSession.email,
+            email,
             chartInfoFromDatabase
           );
         }
@@ -78,10 +80,13 @@ const setupAccountSummaryChartForCaching = (userSession) => {
   });
 };
 
-export const mainSetup = (isMarketClosed, userSession, mutateUser) => {
+/**
+ * @param thisComponent reference of component (this) - in this case Layout.js
+ */
+export const mainSetup = (thisComponent) => {
   return Promise.all([
-    setupSharesListForCaching(isMarketClosed, userSession, mutateUser),
-    setupAccountSummaryChartForCaching(userSession),
+    setupSharesListForCaching(thisComponent),
+    setupAccountSummaryChartForCaching(thisComponent),
   ]);
 };
 

--- a/front-end/src/components/SpeedDial/LayoutSpeedDial.js
+++ b/front-end/src/components/SpeedDial/LayoutSpeedDial.js
@@ -81,11 +81,7 @@ class LayoutSpeedDial extends React.Component {
 
   componentDidMount() {
     this.marketCountdownInterval = setInterval(
-      () =>
-        marketCountdownUpdate(
-          this.setState.bind(this),
-          this.props.isMarketClosed
-        ),
+      () => marketCountdownUpdate(this),
       oneSecond
     );
   }

--- a/front-end/src/utils/RedisUtil.js
+++ b/front-end/src/utils/RedisUtil.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { getBackendHost } from "./low-dependency/NetworkUtil";
 import { parseRedisSharesListItem } from "./low-dependency/ParserUtil";
+import { newDate } from "./low-dependency/DayTimeUtil";
 
 const BACKEND_HOST = getBackendHost();
 
@@ -40,18 +41,20 @@ export const getLatestCachedAccountSummaryChartInfoItem = (email) => {
   });
 };
 
-export const updateCachedAccountSummaryChartInfoOneItem = (
-  email,
-  timestamp,
-  portfolioValue
-) => {
+/**
+ * @description Add new account summary timestamp to cache in back-end
+ * @param thisComponent reference of component (this) - in this case Layout.js
+ */
+export const updateCachedAccountSummaryChartInfoOneItem = (thisComponent) => {
   return new Promise((resolve, reject) => {
+    const { email, totalPortfolio } = thisComponent.props.userSession;
+
     axios(`${BACKEND_HOST}/redis/updateAccountSummaryChartOneItem`, {
       method: "put",
       data: {
         email,
-        timestamp,
-        portfolioValue,
+        timestamp: newDate(),
+        portfolioValue: totalPortfolio,
       },
       withCredentials: true,
     })

--- a/front-end/src/utils/SocketUtil.js
+++ b/front-end/src/utils/SocketUtil.js
@@ -7,15 +7,12 @@ export const updatedRankingListFlag = "updatedRankingListFlag";
 /**
  * @description listen to socket from back-end and update redux isMarketClosed boolean
  * @param socket Initialized in App.js
- * @param mutateMarket redux function to change redux isMarketClosed boolean
+ * @param thisComponent reference of component (this)  - in this case Layout.js
  */
-export const socketCheckMarketClosed = (
-  socket,
-  isMarketClosedInReduxStore,
-  mutateMarket
-) => {
+export const socketCheckMarketClosed = (socket, thisComponent) => {
   socket.on(checkMarketClosed, (ifClosed) => {
-    if (!isEqual(ifClosed, isMarketClosedInReduxStore)) {
+    const { mutateMarket, isMarketClosed } = thisComponent.props;
+    if (!isEqual(ifClosed, isMarketClosed)) {
       if (ifClosed) {
         mutateMarket("closeMarket");
       } else {
@@ -28,23 +25,25 @@ export const socketCheckMarketClosed = (
 /**
  * @description listen to socket from back-end and check against Layout.js updatedAllUsersFlag
  * @param socket Initialized in App.js
- * @param openRefreshCard boolean from Layout state showing whether Refresh Card is shown or not
- * @param hasFinishedSettingUp boolean whether user has finished setting up account
- * @param setState allow after check, open notification in Layout for user to reset the page
+ * @param thisComponent reference of component (this) - in this case Layout.js
  */
 export const checkIsDifferentFromSocketUpdatedAllUsersFlag = (
   socket,
-  updatedAllUsersFlagFromLayoutState,
-  openRefreshCard,
-  hasFinishedSettingUp,
-  setState
+  thisComponent
 ) => {
   socket.on(updatedAllUsersFlag, (flagFromBackend) => {
+    const {
+      updatedAllUsersFlagFromLayout,
+      openRefreshCard,
+    } = thisComponent.state;
+    const { hasFinishedSettingUp } = thisComponent.props.userSession;
+
     if (
-      !isEqual(flagFromBackend, updatedAllUsersFlagFromLayoutState) &&
-      !openRefreshCard
+      !isEqual(flagFromBackend, updatedAllUsersFlagFromLayout) &&
+      !openRefreshCard &&
+      hasFinishedSettingUp
     ) {
-      setState({
+      thisComponent.setState({
         updatedAllUsersFlagFromLayout: flagFromBackend,
         openRefreshCard: true,
       });
@@ -55,23 +54,25 @@ export const checkIsDifferentFromSocketUpdatedAllUsersFlag = (
 /**
  * @description listen to socket from back-end and check against Layout.js updatedRankingFlag
  * @param socket Initialized in App.js
- * @param openRefreshCard boolean from Layout state showing whether Refresh Card is shown or not
- * @param hasFinishedSettingUp boolean whether user has finished setting up account
- * @param setState allow after check, open notification in Layout for user to reset the page
+ * @param thisComponent reference of component (this)  - in this case Layout.js
  */
 export const checkIsDifferentFromSocketUpdatedRankingListFlag = (
   socket,
-  updatedRankingListFlagFromLayoutState,
-  openRefreshCard,
-  hasFinishedSettingUp,
-  setState
+  thisComponent
 ) => {
   socket.on(updatedRankingListFlag, (flagFromBackend) => {
+    const {
+      updatedRankingListFlagFromLayout,
+      openRefreshCard,
+    } = thisComponent.state;
+    const { hasFinishedSettingUp } = thisComponent.props.userSession;
+
     if (
-      !isEqual(flagFromBackend, updatedRankingListFlagFromLayoutState) &&
-      !openRefreshCard
+      !isEqual(flagFromBackend, updatedRankingListFlagFromLayout) &&
+      !openRefreshCard &&
+      hasFinishedSettingUp
     ) {
-      setState({
+      thisComponent.setState({
         updatedRankingListFlagFromLayout: flagFromBackend,
         openRefreshCard: true,
       });

--- a/front-end/src/utils/UserUtil.js
+++ b/front-end/src/utils/UserUtil.js
@@ -343,17 +343,14 @@ export const checkStockQuotesForUser = (isMarketClosed, email) => {
 /**
  * @description_1 Check stock info (quote, profile) for User -> Take from cached stock bank in back-end
  * @description_2 mutate userSession in Redux and update user data in database if totalPortfolio is new and updated.
- * @param isMarketClosed redux boolean check if market is closed
- * @param userSession redux userSession -> user data initialized using back-end
- * @param mutateUser redux function to mutate redux userSession
+ * @param thisComponent reference of component (this) - in this case Layout.js
  */
-export const checkStockQuotesToCalculateSharesValue = (
-  isMarketClosed,
-  userSession,
-  mutateUser
-) => {
+export const checkStockQuotesToCalculateSharesValue = (thisComponent) => {
+  const { isMarketClosed, mutateUser } = thisComponent.props;
+  const { email, cash, totalPortfolio } = thisComponent.props.userSession;
+
   // example of stockQuotesJSON in back-end/utils/FinancialModelingPrepUtil.js
-  checkStockQuotesForUser(isMarketClosed, userSession.email)
+  checkStockQuotesForUser(isMarketClosed, email)
     .then(([stockQuotesJSON, cachedShares]) => {
       const totalSharesValue = calculateTotalSharesValue(
         isMarketClosed,
@@ -361,7 +358,7 @@ export const checkStockQuotesToCalculateSharesValue = (
         cachedShares
       );
 
-      const newTotalPortfolioValue = userSession.cash + totalSharesValue;
+      const newTotalPortfolioValue = cash + totalSharesValue;
 
       /**
        * changeData so that when we reload page or go to other page, the data
@@ -374,9 +371,9 @@ export const checkStockQuotesToCalculateSharesValue = (
 
       if (
         newTotalPortfolioValue &&
-        !isEqual(newTotalPortfolioValue, userSession.totalPortfolio)
+        !isEqual(newTotalPortfolioValue, totalPortfolio)
       ) {
-        return changeUserData(dataNeedChange, userSession.email, mutateUser);
+        return changeUserData(dataNeedChange, email, mutateUser);
       } else {
         //console.log("No need to update user data.");
       }

--- a/front-end/src/utils/low-dependency/DayTimeUtil.js
+++ b/front-end/src/utils/low-dependency/DayTimeUtil.js
@@ -82,7 +82,11 @@ export const newDate = () => {
   return timeNow;
 };
 
-export const marketCountdownUpdate = (setStateFn, isMarketClosed) => {
+/**
+ * @param thisComponent reference of component (this) - in this case LayoutSpeedDial.js
+ */
+export const marketCountdownUpdate = (thisComponent) => {
+  const { isMarketClosed } = thisComponent.props;
   if (isMarketClosed) {
     return;
   }
@@ -114,7 +118,7 @@ export const marketCountdownUpdate = (setStateFn, isMarketClosed) => {
 
   //console.log(countdown);
 
-  setStateFn({
+  thisComponent.setState({
     countdown,
   });
 };


### PR DESCRIPTION
- I realize that intervals and socket listeners (in Layout.js) needs dynamic parameters (references)
-> Pass the whole reference of component (this) to these intervals and listeners

- When update all users in back-end, clear cache for account summary chart of each user. Layout.js will automatically check and update cache for this again.