### PR TITLE
Updates on getManyFullStocksInfo

### DIFF
--- a/back-end/index.js
+++ b/back-end/index.js
@@ -145,8 +145,18 @@ setInterval(() => updateRankingList(globalBackendVariables), 10 * oneMinute);
 
 /*
 Update Cached Shares
-setInterval(() => updateCachedShareQuotesUsingCache(), 2 * oneSecond);
-setInterval(() => updateCachedShareProfilesUsingCache(), oneMinute);
+
+setInterval(() => {
+  if(!globalBackendVariables.isMarketClosed) {
+    updateCachedShareQuotesUsingCache();
+  }
+}, 2 * oneSecond);
+
+setInterval(() => {
+  if(!globalBackendVariables.isMarketClosed) {
+    updateCachedShareProfilesUsingCache();
+  }
+}, oneMinute);
 */
 
 // All app routes are written below this comment:

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -1953,14 +1953,14 @@
       }
     },
     "@prisma/cli": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/cli/-/cli-2.7.1.tgz",
-      "integrity": "sha512-0uA+gWkNQ35DveVHDPltiTCTr4wcXtEhnPs463IEM+Xn8dTv9x0gtZiYHSuQM3t7uwlOxj1rurBsqSbiljynfQ=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/cli/-/cli-2.8.0.tgz",
+      "integrity": "sha512-Kg1C47d75jdEIMmJif8TMlv/2Ihx08E1qWp0euwoZhjd807HGnjgC9tJYjTfkdf+NMJSAUbvoPXKInEX0HoOMw=="
     },
     "@prisma/client": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.7.1.tgz",
-      "integrity": "sha512-IEWDCuvIaQTira8/jAyf+uY+AuPPUFDIXMSN4zEA/gvoJv2woq7RmkaubS+NQVgDbbyOR6F3UcXLiFTYQDzZkQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-2.8.0.tgz",
+      "integrity": "sha512-5+GzRTkPnmv4OEV2tB8kwQt/xLLxBR/daJBcMt6pnnonJvrREsu0tSTdz2LJNPaj3kTT0fSS/OaeGMMdfVYSpw==",
       "requires": {
         "pkg-up": "^3.1.0"
       }

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.10.5",
-    "@prisma/cli": "^2.7.1",
-    "@prisma/client": "^2.7.1",
+    "@prisma/cli": "^2.8.0",
+    "@prisma/client": "^2.8.0",
     "@sendgrid/mail": "^7.2.1",
     "algoliasearch": "^4.3.0",
     "body-parser": "^1.19.0",

--- a/back-end/utils/low-dependency/ParserUtil.js
+++ b/back-end/utils/low-dependency/ParserUtil.js
@@ -21,34 +21,90 @@ const parseCachedMarketHoliday = (redisString) => {
 };
 
 /**
+ * @param marketHoliday Market Holiday object obtained from Database
+ * @returns Redis market holiday value used for cache
+ */
+const createRedisValueFromMarketHoliday = (marketHoliday) => {
+  const {
+    id,
+    year,
+    newYearsDay,
+    martinLutherKingJrDay,
+    washingtonBirthday,
+    goodFriday,
+    memorialDay,
+    independenceDay,
+    laborDay,
+    thanksgivingDay,
+    christmas
+  } = marketHoliday;
+
+  return `${id}|${year}|${newYearsDay}|${martinLutherKingJrDay}|${washingtonBirthday}|${goodFriday}|${memorialDay}|${independenceDay}|${laborDay}|${thanksgivingDay}|${christmas}`;
+};
+
+/**
  * @param redisString From 'cachedShares|AAPL|quote' -> 'name|price|changesPercentage|change|dayLow|dayHigh|yearHigh|yearLow|marketCap|priceAvg50|priceAvg200|volume|avgVolume|exchange|open|previousClose|eps|pe|earningsAnnouncement|sharesOutstanding|timestamp'
  */
 const parseCachedShareQuote = (redisString) => {
   const valuesArray = redisString.split("|");
 
   return {
-    name: valuesArray[0],
-    price: parseFloat(valuesArray[1]),
-    changesPercentage: parseFloat(valuesArray[2]),
-    change: parseFloat(valuesArray[3]),
-    dayLow: parseFloat(valuesArray[4]),
-    dayHigh: parseFloat(valuesArray[5]),
-    yearHigh: parseFloat(valuesArray[6]),
-    yearLow: parseFloat(valuesArray[7]),
-    marketCap: parseFloat(valuesArray[8]),
-    priceAvg50: parseFloat(valuesArray[9]),
-    priceAvg200: parseFloat(valuesArray[10]),
-    volume: parseInt(valuesArray[11], 10),
-    avgVolume: parseInt(valuesArray[12], 10),
-    exchange: valuesArray[13],
-    open: parseFloat(valuesArray[14]),
-    previousClose: parseFloat(valuesArray[15]),
-    eps: parseFloat(valuesArray[16]),
-    pe: parseFloat(valuesArray[17]),
-    earningsAnnouncement: valuesArray[18],
-    sharesOutstanding: parseInt(valuesArray[19], 10),
-    timestamp: parseInt(valuesArray[20], 10)
+    symbol: valuesArray[0],
+    name: valuesArray[1],
+    price: parseFloat(valuesArray[2]),
+    changesPercentage: parseFloat(valuesArray[3]),
+    change: parseFloat(valuesArray[4]),
+    dayLow: parseFloat(valuesArray[5]),
+    dayHigh: parseFloat(valuesArray[6]),
+    yearHigh: parseFloat(valuesArray[7]),
+    yearLow: parseFloat(valuesArray[8]),
+    marketCap: parseFloat(valuesArray[9]),
+    priceAvg50: parseFloat(valuesArray[10]),
+    priceAvg200: parseFloat(valuesArray[11]),
+    volume: parseInt(valuesArray[12], 10),
+    avgVolume: parseInt(valuesArray[13], 10),
+    exchange: valuesArray[14],
+    open: parseFloat(valuesArray[15]),
+    previousClose: parseFloat(valuesArray[16]),
+    eps: parseFloat(valuesArray[17]),
+    pe: parseFloat(valuesArray[18]),
+    earningsAnnouncement: valuesArray[19],
+    sharesOutstanding: parseInt(valuesArray[20], 10),
+    timestamp: parseInt(valuesArray[21], 10)
   };
+};
+
+/**
+ * @param stockQuoteJSON Stock quote similar to Financial Modeling Prep '/quote' API
+ * @returns Redis stock quote value used for cache
+ */
+const createRedisValueFromStockQuoteJSON = (stockQuoteJSON) => {
+  const {
+    symbol,
+    name,
+    price,
+    changesPercentage,
+    change,
+    dayLow,
+    dayHigh,
+    yearHigh,
+    yearLow,
+    marketCap,
+    priceAvg50,
+    priceAvg200,
+    volume,
+    avgVolume,
+    exchange,
+    open,
+    previousClose,
+    eps,
+    pe,
+    earningsAnnouncement,
+    sharesOutstanding,
+    timestamp
+  } = stockQuoteJSON;
+
+  return `${symbol}|${name}|${price}|${changesPercentage}|${change}|${dayLow}|${dayHigh}|${yearHigh}|${yearLow}|${marketCap}|${priceAvg50}|${priceAvg200}|${volume}|${avgVolume}|${exchange}|${open}|${previousClose}|${eps}|${pe}|${earningsAnnouncement}|${sharesOutstanding}|${timestamp}`;
 };
 
 /**
@@ -58,96 +114,72 @@ const parseCachedShareProfile = (redisString) => {
   const valuesArray = redisString.split("|");
 
   return {
-    price: parseFloat(valuesArray[0]),
-    beta: parseFloat(valuesArray[1]),
-    volAvg: parseInt(valuesArray[2], 10),
-    mktCap: parseInt(valuesArray[3], 10),
-    lastDiv: parseFloat(valuesArray[4]),
-    range: valuesArray[5],
-    changes: parseFloat(valuesArray[6]),
-    companyName: valuesArray[7],
-    exchange: valuesArray[8],
-    exchangeShortName: valuesArray[9],
-    industry: valuesArray[10],
-    website: valuesArray[11],
-    description: valuesArray[12],
-    ceo: valuesArray[13],
-    sector: valuesArray[14],
-    country: valuesArray[15],
-    fullTimeEmployees: parseInt(valuesArray[16], 10),
-    phone: valuesArray[17],
-    address: valuesArray[18],
-    city: valuesArray[19],
-    state: valuesArray[20],
-    zip: parseInt(valuesArray[21], 10),
-    dcfDiff: parseFloat(valuesArray[22]),
-    dcf: parseFloat(valuesArray[23]),
-    image: valuesArray[24],
-    ipoDate: new Date(valuesArray[25])
+    symbol: valuesArray[0],
+    price: parseFloat(valuesArray[1]),
+    beta: parseFloat(valuesArray[2]),
+    volAvg: parseInt(valuesArray[3], 10),
+    mktCap: parseInt(valuesArray[4], 10),
+    lastDiv: parseFloat(valuesArray[5]),
+    range: valuesArray[6],
+    changes: parseFloat(valuesArray[7]),
+    companyName: valuesArray[8],
+    exchange: valuesArray[9],
+    exchangeShortName: valuesArray[10],
+    industry: valuesArray[11],
+    website: valuesArray[12],
+    description: valuesArray[13],
+    ceo: valuesArray[14],
+    sector: valuesArray[15],
+    country: valuesArray[16],
+    fullTimeEmployees: parseInt(valuesArray[17], 10),
+    phone: valuesArray[18],
+    address: valuesArray[19],
+    city: valuesArray[20],
+    state: valuesArray[21],
+    zip: parseInt(valuesArray[22], 10),
+    dcfDiff: parseFloat(valuesArray[23]),
+    dcf: parseFloat(valuesArray[24]),
+    image: valuesArray[25],
+    ipoDate: new Date(valuesArray[26])
   };
 };
 
 /**
- * @param finishedTransaction Prisma Model Transaction with isFinished attribute == TRUE
- * @returns Finished Transaction redis string
+ * @param stockProfileJSON Stock profile similar to Financial Modeling Prep '/profile' API
+ * @returns Redis stock profile value used for cache
  */
-const createRedisValueFromFinishedTransaction = (finishedTransaction) => {
+const createRedisValueFromStockProfileJSON = (stockProfileJSON) => {
   const {
-    id,
-    createdAt,
-    companyCode,
-    quantity,
-    priceAtTransaction,
-    brokerage,
-    spendOrGain,
-    finishedTime,
-    isTypeBuy,
-    userID
-  } = finishedTransaction;
-  return `${id}|${createdAt}|${companyCode}|${quantity}|${priceAtTransaction}|${brokerage}|${spendOrGain}|${finishedTime}|${isTypeBuy}|${userID}`;
-};
-
-/**
- * @param filters
- * {
- *    type: buy, sell, OR none
- *    code: none OR random string with NO String ";" -> this is special character used when these attributes in a string
- *    quantity: (int/none)_to_(int/none)
- *    price: (int/none)_to_(int/none)
- *    brokerage: (int/none)_to_(int/none)
- *    spendOrGain: (int/none)_to_(int/none)
- *    transactionTime: (DateTime/none)_to_(DateTime/none)
- * }
- * @returns Transactions History filters redis string
- */
-const createRedisValueFromTransactionsHistoryFilters = (filters) => {
-  const {
-    type,
-    code,
-    quantity,
+    symbol,
     price,
-    brokerage,
-    spendOrGain,
-    transactionTime
-  } = filters;
-  return `${type};${code};${quantity};${price};${brokerage};${spendOrGain};${transactionTime}`;
-};
+    beta,
+    volAvg,
+    mktCap,
+    lastDiv,
+    range,
+    changes,
+    companyName,
+    exchange,
+    exchangeShortName,
+    industry,
+    website,
+    description,
+    ceo,
+    sector,
+    country,
+    fullTimeEmployees,
+    phone,
+    address,
+    city,
+    state,
+    zip,
+    dcfDiff,
+    dcf,
+    image,
+    ipoDate
+  } = stockProfileJSON;
 
-/**
- * @param redisValue `type;code;quantity;price;brokerage;spendOrGain;transactionTime`
- * @returns Transactions History filter object
- */
-const parseRedisTransactionsHistoryFilters = (redisValue) => {
-  const values = redisValue.split(";");
-  return {
-    type: values[0],
-    code: values[1],
-    quantity: values[2].split("_to_"),
-    price: values[3].split("_to_"),
-    brokerage: values[4].split("_to_"),
-    spendOrGain: values[5].split("_to_"),
-    transactionTime: values[6].split("_to_")
-  };
+  return `${symbol}|${price}|${beta}|${volAvg}|${mktCap}|${lastDiv}|${range}|${changes}|${companyName}|${exchange}|${exchangeShortName}|${industry}|${website}|${description}|${ceo}|${sector}|${country}|${fullTimeEmployees}|${phone}|${address}|${city}|${state}|${zip}|${dcfDiff}|${dcf}|${image}|${ipoDate}`;
 };
 
 /**
@@ -224,102 +256,46 @@ const createPrismaFiltersObject = (filters) => {
 };
 
 /**
- * @param marketHoliday Market Holiday object obtained from Database
- * @returns Redis market holiday value used for cache
+ * @param filters
+ * {
+ *    type: buy, sell, OR none
+ *    code: none OR random string with NO String ";" -> this is special character used when these attributes in a string
+ *    quantity: (int/none)_to_(int/none)
+ *    price: (int/none)_to_(int/none)
+ *    brokerage: (int/none)_to_(int/none)
+ *    spendOrGain: (int/none)_to_(int/none)
+ *    transactionTime: (DateTime/none)_to_(DateTime/none)
+ * }
+ * @returns Transactions History filters redis string
  */
-const createRedisValueFromMarketHoliday = (marketHoliday) => {
+const createRedisValueFromTransactionsHistoryFilters = (filters) => {
   const {
-    id,
-    year,
-    newYearsDay,
-    martinLutherKingJrDay,
-    washingtonBirthday,
-    goodFriday,
-    memorialDay,
-    independenceDay,
-    laborDay,
-    thanksgivingDay,
-    christmas
-  } = marketHoliday;
-
-  return `${id}|${year}|${newYearsDay}|${martinLutherKingJrDay}|${washingtonBirthday}|${goodFriday}|${memorialDay}|${independenceDay}|${laborDay}|${thanksgivingDay}|${christmas}`;
-};
-
-/**
- * @param stockQuoteJSON Stock quote similar to Financial Modeling Prep '/quote' API
- * @returns Redis stock quote value used for cache
- */
-const createRedisValueFromStockQuoteJSON = (stockQuoteJSON) => {
-  const {
-    name,
+    type,
+    code,
+    quantity,
     price,
-    changesPercentage,
-    change,
-    dayLow,
-    dayHigh,
-    yearHigh,
-    yearLow,
-    marketCap,
-    priceAvg50,
-    priceAvg200,
-    volume,
-    avgVolume,
-    exchange,
-    open,
-    previousClose,
-    eps,
-    pe,
-    earningsAnnouncement,
-    sharesOutstanding,
-    timestamp
-  } = stockQuoteJSON;
-
-  return `${name}|${price}|${changesPercentage}|${change}|${dayLow}|${dayHigh}|${yearHigh}|${yearLow}|${marketCap}|${priceAvg50}|${priceAvg200}|${volume}|${avgVolume}|${exchange}|${open}|${previousClose}|${eps}|${pe}|${earningsAnnouncement}|${sharesOutstanding}|${timestamp}`;
+    brokerage,
+    spendOrGain,
+    transactionTime
+  } = filters;
+  return `${type};${code};${quantity};${price};${brokerage};${spendOrGain};${transactionTime}`;
 };
 
 /**
- * @param stockProfileJSON Stock profile similar to Financial Modeling Prep '/profile' API
- * @returns Redis stock profile value used for cache
+ * @param redisValue `type;code;quantity;price;brokerage;spendOrGain;transactionTime`
+ * @returns Transactions History filter object
  */
-const createRedisValueFromStockProfileJSON = (stockProfileJSON) => {
-  const {
-    price,
-    beta,
-    volAvg,
-    mktCap,
-    lastDiv,
-    range,
-    changes,
-    companyName,
-    exchange,
-    exchangeShortName,
-    industry,
-    website,
-    description,
-    ceo,
-    sector,
-    country,
-    fullTimeEmployees,
-    phone,
-    address,
-    city,
-    state,
-    zip,
-    dcfDiff,
-    dcf,
-    image,
-    ipoDate
-  } = stockProfileJSON;
-
-  return `${price}|${beta}|${volAvg}|${mktCap}|${lastDiv}|${range}|${changes}|${companyName}|${exchange}|${exchangeShortName}|${industry}|${website}|${description}|${ceo}|${sector}|${country}|${fullTimeEmployees}|${phone}|${address}|${city}|${state}|${zip}|${dcfDiff}|${dcf}|${image}|${ipoDate}`;
-};
-
-/**
- * @param cachedSharesList Shares list of symbols ['AAPL', 'GOOGL', 'FB', ...]
- * @returns Redis symbols string value used for cache
- */
-const createSymbolsStringFromCachedSharesList = (cachedSharesList) => {
-  return cachedSharesList.join();
+const parseRedisTransactionsHistoryFilters = (redisValue) => {
+  const values = redisValue.split(";");
+  return {
+    type: values[0],
+    code: values[1],
+    quantity: values[2].split("_to_"),
+    price: values[3].split("_to_"),
+    brokerage: values[4].split("_to_"),
+    spendOrGain: values[5].split("_to_"),
+    transactionTime: values[6].split("_to_")
+  };
 };
 
 /**
@@ -332,6 +308,34 @@ const combineFMPStockQuoteAndProfile = (stockQuoteJSON, stockProfileJSON) => {
     ...stockQuoteJSON,
     ...stockProfileJSON
   };
+};
+
+/**
+ * @param cachedSharesList Shares list of symbols ['AAPL', 'GOOGL', 'FB', ...]
+ * @returns Redis symbols string value used for cache
+ */
+const createSymbolsStringFromCachedSharesList = (cachedSharesList) => {
+  return cachedSharesList.join();
+};
+
+/**
+ * @param finishedTransaction Prisma Model Transaction with isFinished attribute == TRUE
+ * @returns Finished Transaction redis string
+ */
+const createRedisValueFromFinishedTransaction = (finishedTransaction) => {
+  const {
+    id,
+    createdAt,
+    companyCode,
+    quantity,
+    priceAtTransaction,
+    brokerage,
+    spendOrGain,
+    finishedTime,
+    isTypeBuy,
+    userID
+  } = finishedTransaction;
+  return `${id}|${createdAt}|${companyCode}|${quantity}|${priceAtTransaction}|${brokerage}|${spendOrGain}|${finishedTime}|${isTypeBuy}|${userID}`;
 };
 
 /**
@@ -350,9 +354,11 @@ module.exports = {
   createRedisValueFromMarketHoliday,
 
   parseCachedShareQuote,
-  parseCachedShareProfile,
   createRedisValueFromStockQuoteJSON,
+
+  parseCachedShareProfile,
   createRedisValueFromStockProfileJSON,
+
   combineFMPStockQuoteAndProfile,
   createSymbolsStringFromCachedSharesList,
 

--- a/back-end/utils/redis-utils/SharesInfoBank.js
+++ b/back-end/utils/redis-utils/SharesInfoBank.js
@@ -82,14 +82,6 @@ const getSingleCachedShareInfo = (companyCode) => {
           resolve(shareInfoObject);
         }
       })
-      .then((finishedUpdating) => {
-        if (finishedUpdating) {
-          console.log(
-            finishedUpdating,
-            "RedisUtil.js getSingleCachedShareInfo"
-          );
-        }
-      })
       .catch((err) => {
         reject(err);
       });

--- a/front-end/src/components/Layout/Layout.js
+++ b/front-end/src/components/Layout/Layout.js
@@ -129,12 +129,12 @@ class Layout extends React.Component {
   };
 
   setupIntervals = () => {
-    if (this.props.userSession.hasFinishedSettingUp) {
-      // this.checkStockQuotesInterval = setInterval(
-      //   () => checkStockQuotesToCalculateSharesValue(this),
-      //   30 * oneSecond
-      // );
-    }
+    // if (this.props.userSession.hasFinishedSettingUp) {
+    //   this.checkStockQuotesInterval = setInterval(
+    //     () => checkStockQuotesToCalculateSharesValue(this),
+    //     30 * oneSecond
+    //   );
+    // }
   };
 
   setupSocketListeners = () => {

--- a/front-end/src/utils/RedisUtil.js
+++ b/front-end/src/utils/RedisUtil.js
@@ -4,9 +4,20 @@ import { parseRedisSharesListItem } from "./low-dependency/ParserUtil";
 
 const BACKEND_HOST = getBackendHost();
 
+// const updateAccountSummaryChartWholeList = "updateAccountSummaryChartWholeList";
+// const updateAccountSummaryChartOneItem = "updateAccountSummaryChartOneItem";
+const getAccountSummaryChartWholeList = "getAccountSummaryChartWholeList";
+// const getAccountSummaryChartLatestItem = "getAccountSummaryChartLatestItem";
+
+// const updateSharesList = "updateSharesList";
+const getSharesList = "getSharesList";
+
+const getCachedShareInfo = "getCachedShareInfo";
+const getManyCachedSharesInfo = "getManyCachedSharesInfo";
+
 export const getCachedAccountSummaryChartInfo = (email) => {
   return new Promise((resolve, reject) => {
-    axios(`${BACKEND_HOST}/redis/getAccountSummaryChartWholeList`, {
+    axios(`${BACKEND_HOST}/redis/${getAccountSummaryChartWholeList}`, {
       method: "get",
       params: {
         email,
@@ -24,7 +35,7 @@ export const getCachedAccountSummaryChartInfo = (email) => {
 
 export const getCachedSharesList = (email) => {
   return new Promise((resolve, reject) => {
-    axios(`${BACKEND_HOST}/redis/getSharesList`, {
+    axios(`${BACKEND_HOST}/redis/${getSharesList}`, {
       method: "get",
       params: {
         email,
@@ -58,38 +69,13 @@ export const getParsedCachedSharesList = (email) => {
   });
 };
 
-/** 
- * Example response of full stock:
- * [ {
-  "symbol" : "AAPL",
-  "name" : "Apple Inc.",
-  "price" : 425.04000000,
-  "changesPercentage" : 10.47000000,
-  "change" : 40.28000000,
-  "dayLow" : 403.36000000,
-  "dayHigh" : 425.66000000,
-  "yearHigh" : 425.66000000,
-  "yearLow" : 192.58000000,
-  "marketCap" : 1842263621632.00000000,
-  "priceAvg50" : 372.20715000,
-  "priceAvg200" : 314.67236000,
-  "volume" : 93573867,
-  "avgVolume" : 35427873,
-  "exchange" : "NASDAQ",
-  "open" : 411.53500000,
-  "previousClose" : 384.76000000,
-  "eps" : 13.18500000,
-  "pe" : 32.23663300,
-  "earningsAnnouncement" : "2020-07-30T20:00:00.000+0000",
-  "sharesOutstanding" : 4334329996,
-  "timestamp" : 1596329461
-},
- ...
-]
+/**
+ * @param {string} companyCode company code. e.g: AAPl -> Must be in capital
+ * @description Get full stock quote + profile (using FMP data)
  */
 export const getFullStockInfo = (companyCode) => {
   return new Promise((resolve, reject) => {
-    axios(`${BACKEND_HOST}/redis/getCachedShareInfo`, {
+    axios(`${BACKEND_HOST}/redis/${getCachedShareInfo}`, {
       method: "get",
       params: {
         companyCode,
@@ -106,15 +92,42 @@ export const getFullStockInfo = (companyCode) => {
   });
 };
 
-export const getManyStockInfosUsingPrismaShares = (prismaShares) => {
-  // prismaShares means: shares with companyCode attribute
-  // prismaShares won't be empty since you need to eliminate that case before using this function
-
+/**
+ * @param {string[]} companyCodes company codes. e.g: AAPL, GOOGL, ... -> Must be in capital
+ * @description Get full stock quote + profile (using FMP data) of all company codes in parameter
+ */
+export const getManyFullStocksInfo = (companyCodes) => {
   return new Promise((resolve, reject) => {
-    const getCachedSharesInfoPromiseArray = prismaShares.map((share, index) => {
-      return getFullStockInfo(share.companyCode);
+    axios(`${BACKEND_HOST}/redis/${getManyCachedSharesInfo}`, {
+      method: "get",
+      params: {
+        companyCodes,
+      },
+      withCredentials: true,
+    })
+      .then((sharesInfo) => {
+        const { data: fullStocksInfo } = sharesInfo;
+        resolve(fullStocksInfo);
+      })
+      .catch((err) => {
+        reject(err);
+      });
+  });
+};
+
+/**
+ * @param {object[]} prismaShares objects of Prisma Share
+ * - prismaShares means: shares with companyCode attribute
+ * - prismaShares won't be empty since you need to eliminate that case before using this function
+ * @description Wrapper over function getManyFullStocksInfo
+ * @return {Promise<object[]>}
+ */
+export const getManyStockInfosUsingPrismaShares = (prismaShares) => {
+  return new Promise((resolve, reject) => {
+    const companyCodes = prismaShares.map((share) => {
+      return share.companyCode;
     });
-    Promise.all(getCachedSharesInfoPromiseArray)
+    getManyFullStocksInfo(companyCodes)
       .then((cachedSharesArray) => {
         resolve(cachedSharesArray);
       })
@@ -131,5 +144,7 @@ export default {
   getParsedCachedSharesList, // AccountSummary, UserUtil
 
   getFullStockInfo,
+  getManyFullStocksInfo,
+
   getManyStockInfosUsingPrismaShares,
 };


### PR DESCRIPTION
- Pump @prisma/cli and @prisma/client to 2.8.0

- routes/redis.js (back-end): create route /getManyCachedSharesInfo to execute getSingleCachedShareInfo many times according to the param companyCodes

- routes/user.js (back-end): add "default" option to getUserData route

- Add attribute symbol to cachedShareQuote and cachedShareProfile  

- utils/RedisUtil (front-end): create getManyFullStocksInfo, change getManyStockInfosUsingPrismaShares

- utils/UserUtil (front-end): fix checkStockQuotesForUser to be less confusing